### PR TITLE
Bugfix/shadow opacity animation

### DIFF
--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -713,18 +713,18 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 {
     if (self.parallaxEnabled) {
         IF_IOS7_OR_GREATER(
-                           for (UIMotionEffect *effect in self.menuViewContainer.motionEffects) {
-                               [self.menuViewContainer removeMotionEffect:effect];
-                           } UIInterpolatingMotionEffect *interpolationHorizontal = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
-                           interpolationHorizontal.minimumRelativeValue = @(self.parallaxMenuMinimumRelativeValue);
-                           interpolationHorizontal.maximumRelativeValue = @(self.parallaxMenuMaximumRelativeValue);
+            for (UIMotionEffect *effect in self.menuViewContainer.motionEffects) {
+               [self.menuViewContainer removeMotionEffect:effect];
+            } UIInterpolatingMotionEffect *interpolationHorizontal = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+            interpolationHorizontal.minimumRelativeValue = @(self.parallaxMenuMinimumRelativeValue);
+            interpolationHorizontal.maximumRelativeValue = @(self.parallaxMenuMaximumRelativeValue);
 
-                           UIInterpolatingMotionEffect *interpolationVertical = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
-                           interpolationVertical.minimumRelativeValue = @(self.parallaxMenuMinimumRelativeValue);
-                           interpolationVertical.maximumRelativeValue = @(self.parallaxMenuMaximumRelativeValue);
+            UIInterpolatingMotionEffect *interpolationVertical = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+            interpolationVertical.minimumRelativeValue = @(self.parallaxMenuMinimumRelativeValue);
+            interpolationVertical.maximumRelativeValue = @(self.parallaxMenuMaximumRelativeValue);
 
-                           [self.menuViewContainer addMotionEffect:interpolationHorizontal];
-                           [self.menuViewContainer addMotionEffect:interpolationVertical];);
+            [self.menuViewContainer addMotionEffect:interpolationHorizontal];
+            [self.menuViewContainer addMotionEffect:interpolationVertical];);
     }
 }
 
@@ -732,21 +732,22 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 {
     if (self.parallaxEnabled) {
         IF_IOS7_OR_GREATER(
-                           for (UIMotionEffect *effect in self.contentViewContainer.motionEffects) {
-                               [self.contentViewContainer removeMotionEffect:effect];
-                           }
-                           [UIView animateWithDuration:0.2 animations:^{
-            UIInterpolatingMotionEffect *interpolationHorizontal = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
-            interpolationHorizontal.minimumRelativeValue = @(self.parallaxContentMinimumRelativeValue);
-            interpolationHorizontal.maximumRelativeValue = @(self.parallaxContentMaximumRelativeValue);
+            for (UIMotionEffect *effect in self.contentViewContainer.motionEffects) {
+               [self.contentViewContainer removeMotionEffect:effect];
+            }
+            [UIView animateWithDuration:0.2 animations:^{
+                UIInterpolatingMotionEffect *interpolationHorizontal = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.x" type:UIInterpolatingMotionEffectTypeTiltAlongHorizontalAxis];
+                interpolationHorizontal.minimumRelativeValue = @(self.parallaxContentMinimumRelativeValue);
+                interpolationHorizontal.maximumRelativeValue = @(self.parallaxContentMaximumRelativeValue);
 
-            UIInterpolatingMotionEffect *interpolationVertical = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
-            interpolationVertical.minimumRelativeValue = @(self.parallaxContentMinimumRelativeValue);
-            interpolationVertical.maximumRelativeValue = @(self.parallaxContentMaximumRelativeValue);
+                UIInterpolatingMotionEffect *interpolationVertical = [[UIInterpolatingMotionEffect alloc] initWithKeyPath:@"center.y" type:UIInterpolatingMotionEffectTypeTiltAlongVerticalAxis];
+                interpolationVertical.minimumRelativeValue = @(self.parallaxContentMinimumRelativeValue);
+                interpolationVertical.maximumRelativeValue = @(self.parallaxContentMaximumRelativeValue);
 
-            [self.contentViewContainer addMotionEffect:interpolationHorizontal];
-            [self.contentViewContainer addMotionEffect:interpolationVertical];
-        }];);
+                [self.contentViewContainer addMotionEffect:interpolationHorizontal];
+                [self.contentViewContainer addMotionEffect:interpolationVertical];
+            }];
+        );
     }
 }
 

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -162,7 +162,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 }
 
 -(UIImage *)contentViewImageSnapshot {
-    if(!_contentViewImageSnapshot) {
+    if (!_contentViewImageSnapshot) {
         UIEdgeInsets edgeInsets = UIEdgeInsetsMake(1, 0, 1, 0);
         _contentViewImageSnapshot = [self renderImageFromView:self.contentViewContainer withRect:self.contentViewContainer.bounds transparentInsets:edgeInsets];
     }
@@ -538,7 +538,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     
     // Perspective shadow animation
     CABasicAnimation *shadowAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
-    shadowAnimation.fromValue = [(NSNumber *)self.perspectiveShadowLayer valueForKeyPath:@"opacity"];
+    shadowAnimation.fromValue = (NSNumber *)[self.perspectiveShadowLayer valueForKeyPath:@"opacity"];
     shadowAnimation.toValue = @(self.perspectiveShadowOpacity);
     shadowAnimation.duration = self.animationDuration;
     self.perspectiveShadowLayer.opacity = self.perspectiveShadowOpacity;
@@ -631,9 +631,9 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 
     NSNumber *rotationFromValue = @(0.0);
     if (isHidingRightMenu) {
-            rotationFromValue = @(-self.perspectiveRotationAmountRadians);
+        rotationFromValue = @(-self.perspectiveRotationAmountRadians);
     } else {
-            rotationFromValue = @(self.perspectiveRotationAmountRadians);
+        rotationFromValue = @(self.perspectiveRotationAmountRadians);
     }
 
     // Reverse perspective rotation and shadow animations
@@ -645,7 +645,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
             self.contentViewImageSnapshot = nil;
         }];
         CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"transform.rotation.y"];
-        animation.fromValue = [(NSNumber *)self.perspectiveAnimationLayer valueForKeyPath:@"transform.rotation.y"];
+        animation.fromValue = (NSNumber *)[self.perspectiveAnimationLayer valueForKeyPath:@"transform.rotation.y"];
         animation.toValue = @0.0;
         animation.duration = self.animationDuration;
         [self.perspectiveAnimationLayer setValue:@0.0 forKeyPath:@"transform.rotation.y"];
@@ -811,7 +811,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         } else {
             delta = point.x / self.view.frame.size.width;
         }
-        delta = MIN(fabs(delta), 1.6);
+        delta = MIN(fabsf(delta), 1.6);
 
         CGFloat contentViewScale = self.scaleContentView ? 1 - ((1 - self.contentViewScaleValue) * delta) : 1;
 
@@ -896,7 +896,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         }
         
         //3d rotation
-        float fractionFromLeftEdge = 1 - (fabs(point.x) / (self.view.frame.size.width - self.contentViewContainer.frame.size.width/2));
+        float fractionFromLeftEdge = 1 - (fabsf(point.x) / (self.view.frame.size.width - self.contentViewContainer.frame.size.width/2));
         float angle = self.perspectiveRotationAmountRadians * fractionFromLeftEdge;
         [CATransaction begin];
         {
@@ -910,7 +910,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
             CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
             float fromOpacityValue = self.perspectiveShadowLayer.opacity;
             opacityAnimation.fromValue = @(fromOpacityValue);
-            float opacityToValue = fabs(fractionFromLeftEdge) * self.perspectiveShadowOpacity;
+            float opacityToValue = fabsf(fractionFromLeftEdge) * self.perspectiveShadowOpacity;
             opacityAnimation.toValue = @(opacityToValue);
             opacityAnimation.duration = 0;
             self.perspectiveShadowLayer.opacity = opacityToValue;

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -541,7 +541,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     shadowAnimation.fromValue = [(NSNumber *)self.perspectiveShadowLayer valueForKeyPath:@"opacity"];
     shadowAnimation.toValue = @(self.perspectiveShadowOpacity);
     shadowAnimation.duration = self.animationDuration;
-    self.perspectiveShadowLayer.opacity = [shadowAnimation.toValue floatValue];
+    self.perspectiveShadowLayer.opacity = self.perspectiveShadowOpacity;
     [self.perspectiveShadowLayer addAnimation:shadowAnimation forKey:@"opacity"];
     
     [self statusBarNeedsAppearanceUpdate];
@@ -674,8 +674,6 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         [self addContentButton];
         [self.view.window endEditing:YES];
         self.didNotifyDelegate = NO;
-        
-        //[self buildLayersForGestureInteraction];
     }
 
     if (recognizer.state == UIGestureRecognizerStateChanged) {
@@ -770,7 +768,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         }
         
         //3d rotation
-        float fractionFromLeftEdge = self.contentViewContainer.frame.origin.x / self.view.frame.size.width;
+        float fractionFromLeftEdge = 1 - (fabs(point.x) / (self.view.frame.size.width - self.contentViewContainer.frame.size.width/2));
         float angle = self.perspectiveRotationAmountRadians * fractionFromLeftEdge;
         [CATransaction begin];
         {
@@ -784,9 +782,10 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
             CABasicAnimation *opacityAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
             float fromOpacityValue = self.perspectiveShadowLayer.opacity;
             opacityAnimation.fromValue = @(fromOpacityValue);
-            opacityAnimation.toValue = @(fabs(fractionFromLeftEdge) * self.perspectiveShadowOpacity);
+            float opacityToValue = fabs(fractionFromLeftEdge) * self.perspectiveShadowOpacity;
+            opacityAnimation.toValue = @(opacityToValue);
             opacityAnimation.duration = 0;
-            self.perspectiveShadowLayer.opacity = fabs(fractionFromLeftEdge) * self.perspectiveShadowOpacity;
+            self.perspectiveShadowLayer.opacity = opacityToValue;
             [self.perspectiveShadowLayer addAnimation:opacityAnimation forKey:@"opacity"];
         } [CATransaction commit];
 


### PR DESCRIPTION
This fixes the major issues from the 3d perspective transition work, most notably:
1. No more endlessly duplicated layers when triggering animations from pan gestures.
2. Perspective rotation and opacity interpolate nicely during pan gesture.
3. Latency is greatly reduced by caching the snapshot image for the animation layer only once at the start of the menu display animation, and discarding it when we hide the menu.
