### PR TITLE
Menu fixes

### DIFF
--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -163,7 +163,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 
 -(UIImage *)contentViewImageSnapshot {
     if (!_contentViewImageSnapshot) {
-        UIEdgeInsets edgeInsets = UIEdgeInsetsMake(1, 0, 1, 0);
+        UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
         _contentViewImageSnapshot = [self renderImageFromView:self.contentViewContainer withRect:self.contentViewContainer.bounds transparentInsets:edgeInsets];
     }
 
@@ -372,7 +372,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
 - (void)buildLayersForAnimation
 {
     UIView *contentView = self.contentViewContainer;
-    UIEdgeInsets edgeInsets = UIEdgeInsetsMake(1, 0, 1, 0);
+    UIEdgeInsets edgeInsets = UIEdgeInsetsZero;
 
     UIImage *contentViewSnapshot = nil;
     if ([self.delegate respondsToSelector:@selector(contentSnapshotImageForSideMenu:)]) {
@@ -395,6 +395,8 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     transform.m34 = -1.0 / (contentView.bounds.size.height * 4.6666667);
 
     self.perspectiveAnimationLayer = animationLayer;
+    self.perspectiveAnimationLayer.shouldRasterize = YES;
+    self.perspectiveAnimationLayer.rasterizationScale = [UIScreen mainScreen].scale;
     [contentView.layer addSublayer:self.perspectiveAnimationLayer];
     [self.contentViewController.view setHidden:YES];
 

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -896,7 +896,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         }
         
         //3d rotation
-        float fractionFromLeftEdge = 1 - (fabsf(point.x) / (self.view.frame.size.width - self.contentViewContainer.frame.size.width/2));
+        float fractionFromLeftEdge = 1 - (contentViewScale - self.contentViewScaleValue) / (1.0 - self.contentViewScaleValue);
         float angle = self.perspectiveRotationAmountRadians * fractionFromLeftEdge;
         [CATransaction begin];
         {

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -896,7 +896,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         }
         
         //3d rotation
-        float fractionFromLeftEdge = 1 - (contentViewScale - self.contentViewScaleValue) / (1.0 - self.contentViewScaleValue);
+        float fractionFromLeftEdge = CGAffineTransformIsIdentity(self.contentViewContainer.transform) ? 0 : 1 - (contentViewScale - self.contentViewScaleValue) / (1.0 - self.contentViewScaleValue);
         float angle = self.perspectiveRotationAmountRadians * fractionFromLeftEdge;
         [CATransaction begin];
         {

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -459,8 +459,10 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     
     [self.view.window endEditing:YES];
 
-    [self cleanupAnimationLayers];
-    [self buildLayersForAnimation];
+    if (CGAffineTransformIsIdentity(self.contentViewContainer.transform)) {
+        [self cleanupAnimationLayers];
+        [self buildLayersForAnimation];
+    }
 
     [self addContentButton];
     [self updateContentViewShadow];


### PR DESCRIPTION
This fixes a couple of issues we were seeing with the side menu:
- A "fanning" effect when the menu was swiped closed, and the user kept panning across the screen.
- The content view disappearing if the user swiped the menu open when it was already open.

This also makes a couple of other small changes involving calculating the amount of perspective to apply when panning, and anti-aliases the perspective layer using the built in Core Animation rasterisation.
