### PR TITLE
Appearance glitch fix

### DIFF
--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -825,7 +825,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         } else {
             delta = point.x / self.view.frame.size.width;
         }
-        delta = MIN(fabsf(delta), 1.6);
+        delta = MIN(fabs(delta), 1.6);
 
         CGFloat contentViewScale = self.scaleContentView ? 1 - ((1 - self.contentViewScaleValue) * delta) : 1;
 

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -718,6 +718,14 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     if (controller.childViewControllers.count > 0) {
         [controller beginAppearanceTransition:YES animated:NO];
         [controller endAppearanceTransition];
+        /**
+         *  Must perform the disappear appearance transition in the next runloop
+         *  otherwise iOS relaises that it doesn't need to calculate anything.
+         */
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [controller beginAppearanceTransition:NO animated:NO];
+            [controller endAppearanceTransition];
+        });
     }
 }
 

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -720,7 +720,7 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
         [controller endAppearanceTransition];
         /**
          *  Must perform the disappear appearance transition in the next runloop
-         *  otherwise iOS relaises that it doesn't need to calculate anything.
+         *  otherwise iOS realises that it doesn't need to calculate anything.
          */
         dispatch_async(dispatch_get_main_queue(), ^{
             [controller beginAppearanceTransition:NO animated:NO];

--- a/RESideMenu/RESideMenuController.m
+++ b/RESideMenu/RESideMenuController.m
@@ -265,6 +265,9 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     }
 
     [self updateContentViewShadow];
+    
+    [self performInitialAppearanceTransitionCallsForControllerIfRequired:self.leftMenuViewController];
+    [self performInitialAppearanceTransitionCallsForControllerIfRequired:self.rightMenuViewController];
 }
 
 - (BOOL)shouldAutomaticallyForwardAppearanceMethods
@@ -709,6 +712,13 @@ typedef NS_ENUM(NSInteger, RESideMenuControllerDirection)
     self.contentViewContainer.transform = CGAffineTransformIdentity;
     self.contentViewContainer.transform = CGAffineTransformMakeScale(scale, scale);
     self.contentViewContainer.frame = frame;
+}
+
+- (void)performInitialAppearanceTransitionCallsForControllerIfRequired:(UIViewController *)controller {
+    if (controller.childViewControllers.count > 0) {
+        [controller beginAppearanceTransition:YES animated:NO];
+        [controller endAppearanceTransition];
+    }
 }
 
 #pragma mark - iOS 7 Motion Effects (Private)


### PR DESCRIPTION
You may have noticed when opening the side menu for the first time in OS Maps that the table appears to jump downwards when the "open menu" animation completes. This is because when it first appears, our navigation controller has not passed the height of its navigation bar to the `topLayoutGuide` of our side menu view controller, so our table is laid out with no top content inset set. When the animation finishes, the layout guide has been configured, and the table view is redrawn correctly, with the first row appearing 64 points down the screen so that it doesn't underlap the navigation bar.
The change in this PR checks the menu view controllers to see if they contain child view controllers. If they do, then they will likely benefit from having the layout guide environment configured before they are first displayed to the user. As such, we send the appearance transition begin / end messages to the controllers to force them to configure the environment. Once this has been done, then the first time a menu is shown to the user, it renders correctly.
